### PR TITLE
Create channel before offer sent

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -55,8 +55,7 @@ export default function App() {
 
     // ****** EVENT HANDLERS ******
     function inviteToChat(inviteeName) {
-        rtcConnectionData.current = createRtcConnection(SignallingService.instance, inviteeName);
-        beginConnect(rtcConnectionData.current);
+        rtcConnectionData.current = beginConnect(inviteeName, SignallingService.instance);
 
         setChattingWithUsername(inviteeName);
         setChatState(states.SENDING_OFFER);
@@ -77,8 +76,7 @@ export default function App() {
         const offer = rtcOffer.current;
 
         console.log('Creating RTC connection');
-        rtcConnectionData.current = createRtcConnection(SignallingService.instance, offer.name);
-        handleOffer(rtcConnectionData.current, offer);
+        rtcConnectionData.current = handleOffer(SignallingService.instance, offer);
 
         // TODO don't just throw away if we blow up.
         console.log('Getting rid of stored offer');

--- a/src/services/web-rtc/beginConnect.js
+++ b/src/services/web-rtc/beginConnect.js
@@ -1,7 +1,11 @@
-export default function beginConnect(rtcConnectionData) {
-    const {rtcConnection, remoteUsername, signallingService} = rtcConnectionData;
+import createRtcConnection from "./createRtcConnection";
 
-    const rtcChannel = rtcConnection.createDataChannel('sendChannel');
+export default function beginConnect(remoteUsername, signallingService) {
+    const rtcConnectionData = createRtcConnection(signallingService, remoteUsername);
+
+    const {rtcConnection} = rtcConnectionData;
+
+    rtcConnectionData.rtcChannel = rtcConnection.createDataChannel('sendChannel');
 
     rtcConnection.createOffer()
         .then(offer => rtcConnection.setLocalDescription(offer))
@@ -14,5 +18,5 @@ export default function beginConnect(rtcConnectionData) {
             throw new Error('Error sending offer to remote user.');
         });
 
-    rtcConnectionData.rtcChannel = rtcChannel;
+    return rtcConnectionData;
 }

--- a/src/services/web-rtc/handleAnswer.js
+++ b/src/services/web-rtc/handleAnswer.js
@@ -1,18 +1,22 @@
 export default function handleAnswer(rtcConnectionData, answer) {
-    const {rtcConnection, rtcChannel, iceCandidates, remoteUsername, signallingService} = rtcConnectionData;
+    const {rtcConnection, iceCandidates, remoteUsername, signallingService, rtcChannel} = rtcConnectionData;
     const {isAccepted} = answer;
 
     rtcConnectionData.onAnswer(isAccepted);
 
     if (isAccepted) {
-        rtcConnection.setRemoteDescription(answer.answer);
-
-        rtcChannel.onmessage = (event) => {
-            rtcConnectionData.onMessage(event.data);
-        };
+        rtcConnection.setRemoteDescription(answer.answer)
+            .catch(e => {
+                console.log("Failed to set remote description.");
+                console.log(e);
+            });
 
         while (iceCandidates.length) {
             signallingService.sendCandidate(remoteUsername, iceCandidates.pop());
         }
+
+        rtcChannel.onmessage = (event) => {
+            rtcConnectionData.onMessage(event.data);
+        };
     }
 }

--- a/src/services/web-rtc/handleOffer.js
+++ b/src/services/web-rtc/handleOffer.js
@@ -1,5 +1,10 @@
-export default function handleOffer(rtcConnectionData, data) {
-    const {rtcConnection, signallingService} = rtcConnectionData;
+import createRtcConnection from "./createRtcConnection";
+
+export default function handleOffer(signallingService, offer) {
+
+    const rtcConnectionData = createRtcConnection(signallingService, offer.name);
+
+    const {rtcConnection} = rtcConnectionData;
 
     rtcConnection.ondatachannel = event => {
         rtcConnectionData.rtcChannel = event.channel;
@@ -12,15 +17,17 @@ export default function handleOffer(rtcConnectionData, data) {
         // onClose
     };
 
-    rtcConnection.setRemoteDescription(data.offer)
+    rtcConnection.setRemoteDescription(offer.offer)
         .then(() => rtcConnection.createAnswer())
         .then(answer => rtcConnection.setLocalDescription(answer))
-        .then(() => signallingService.sendAnswer(data.name, true, rtcConnection.localDescription))
+        .then(() => signallingService.sendAnswer(offer.name, true, rtcConnection.localDescription))
         .then(() => {
-            rtcConnectionData.remoteUsername = data.name;
+            rtcConnectionData.remoteUsername = offer.name;
         })
         .catch(e => {
             console.log("Error sending answer: ");
             console.log(e);
         });
+
+    return rtcConnectionData;
 }


### PR DESCRIPTION
Occasionally the onChannelOpen event was not being fired.

With the help of this post: https://stackoverflow.com/questions/38867763/why-i-have-to-open-data-channel-before-send-peer-connection-offer

Discovered that the negotiation process includes negotiating how to handle the channels or anything else created, so they must be created before the offer is sent.